### PR TITLE
Add cli switch for script minification

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -5,6 +5,14 @@ import { compileMap, getFilesInDirectory, loadJsonFile, logger, toArrayBuffer, I
 
 function main() {
   const config: IProjectConfig = loadJsonFile("config.json");
+  const minify = process.argv[2] === '-minify' || config.minifyScript
+
+  if(minify !== config.minifyScript){
+    logger.warn(`minifyScript has been overridden by command line argument "-minify"`)
+    config.minifyScript = minify
+  }
+
+
   const result = compileMap(config);
 
   if (!result) {

--- a/scripts/utils.ts
+++ b/scripts/utils.ts
@@ -7,7 +7,7 @@ const luamin = require('luamin');
 
 export interface IProjectConfig {
   mapFolder: string;
-  minifyScript: string;
+  minifyScript: boolean;
   gameExecutable: string;
   outputFolder: string;
   launchArgs: string[];


### PR DESCRIPTION
This could be used for CI purposes where you might always want to minify a release but not the local builds.

Usage: `$ npm run build -- -minify`

**Note**: I found the interface for the config depicting minifyScript as a string instead of a boolean. Mistake? Fixed it. Seems to work.