### PR TITLE
Support launching with wine

### DIFF
--- a/scripts/test.ts
+++ b/scripts/test.ts
@@ -14,6 +14,7 @@ function main() {
   const filename = `${cwd}/dist/${config.mapFolder}`;
 
   logger.info(`Launching map "${filename.replace(/\\/g, "/")}"...`);
+
   if(config.winePath) {
     const wineFilename = `"Z:${filename}"`
     const prefix = config.winePrefix ? `WINEPREFIX=${config.winePrefix}` : ''
@@ -25,8 +26,6 @@ function main() {
       }
     });
   }
-
-
 }
 
 main();

--- a/scripts/test.ts
+++ b/scripts/test.ts
@@ -1,8 +1,8 @@
-import { execFile } from "child_process";
-import { loadJsonFile, logger, compileMap } from "./utils";
+import {exec, execFile, execSync} from "child_process";
+import {loadJsonFile, logger, compileMap, IProjectConfig} from "./utils";
 
 function main() {
-  const config = loadJsonFile("config.json");
+  const config: IProjectConfig = loadJsonFile("config.json");
   const result = compileMap(config);
 
   if (!result) {
@@ -14,12 +14,19 @@ function main() {
   const filename = `${cwd}/dist/${config.mapFolder}`;
 
   logger.info(`Launching map "${filename.replace(/\\/g, "/")}"...`);
+  if(config.winePath) {
+    const wineFilename = `"Z:${filename}"`
+    const prefix = config.winePrefix ? `WINEPREFIX=${config.winePrefix}` : ''
+    execSync(`${prefix} ${config.winePath} "${config.gameExecutable}" ${["-loadfile", wineFilename, ...config.launchArgs].join(' ')}`, { stdio: 'ignore' });
+  } else {
+    execFile(config.gameExecutable, ["-loadfile", filename, ...config.launchArgs], (err: any) => {
+      if (err && err.code === 'ENOENT') {
+        logger.error(`No such file or directory "${config.gameExecutable}". Make sure gameExecutable is configured properly in config.json.`);
+      }
+    });
+  }
 
-  execFile(config.gameExecutable, ["-loadfile", filename, ...config.launchArgs], (err: any) => {
-    if (err && err.code === 'ENOENT') {
-      logger.error(`No such file or directory "${config.gameExecutable}". Make sure gameExecutable is configured properly in config.json.`);
-    }
-  });
+
 }
 
 main();

--- a/scripts/utils.ts
+++ b/scripts/utils.ts
@@ -11,6 +11,8 @@ export interface IProjectConfig {
   gameExecutable: string;
   outputFolder: string;
   launchArgs: string[];
+  winePath?: string;
+  winePrefix?: string;
 }
 
 /**
@@ -28,7 +30,7 @@ export function loadJsonFile(fname: string) {
 
 /**
  * Convert a Buffer to ArrayBuffer
- * @param buf 
+ * @param buf
  */
 export function toArrayBuffer(b: Buffer): ArrayBuffer {
   var ab = new ArrayBuffer(b.length);
@@ -41,7 +43,7 @@ export function toArrayBuffer(b: Buffer): ArrayBuffer {
 
 /**
  * Convert a ArrayBuffer to Buffer
- * @param ab 
+ * @param ab
  */
 export function toBuffer(ab: ArrayBuffer) {
   var buf = Buffer.alloc(ab.byteLength);
@@ -88,7 +90,7 @@ export function processScriptIncludes(contents: string) {
 }
 
 /**
- * 
+ *
  */
 export function compileMap(config: IProjectConfig) {
   if (!config.mapFolder) {


### PR DESCRIPTION
Adds two new optional config options: 
  "winePath" - Path to wine binary, usually /usr/bin/wine64.
  "winePrefix" - Optional wine prefix, for more advanced users.

If winePath is not set it will launch the usual windows/macos way, if it is set it will switch the filepath to the virtual Z drive. It will also run synchronously so you can use run/stop in jetbrains ide's. 